### PR TITLE
fixed contact us text wrapping issue

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -197,6 +197,7 @@ nav .nav_buttons {
 
   transition-duration: 0.3s;
   position: relative;
+  text-wrap: nowrap;
 }
 
 .nav_buttons .nav_button::after {


### PR DESCRIPTION
Added text-wrap:no-wrap propert  to .nav_buttons .nav_button  