### PR TITLE
[FIX] #105added gap between our goals and footer section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -609,7 +609,7 @@ nav .nav_buttons {
 }
 
 .footer {
-  margin-top: 100px;
+  margin-top: 4.5rem;
   background-color: #141414;
   box-sizing: border-box;
   border-top: 1px solid black;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -609,6 +609,7 @@ nav .nav_buttons {
 }
 
 .footer {
+  margin-top: 100px;
   background-color: #141414;
   box-sizing: border-box;
   border-top: 1px solid black;


### PR DESCRIPTION
# Pull Request Template

## Description
To add a gap between the "Our Goals" section and the footer section, I have added a line in CSS that creates a gap between the two sections.

## Related Issue
Fixes #105

## Changes Made
Given a margin from the top of the footer to increase the gap of **100px**.

## Screenshots 
![image](https://github.com/user-attachments/assets/4f7dfd4c-14c1-4a7a-9b8b-38224e3083a5)

## Checklist
- [x] I have read the contributing guidelines.
- [x] I have tested my changes.
- [x] My code follows the code style of this project.