### PR TITLE
Fixed Social Media Tab overflow in smaller screens

### DIFF
--- a/about.html
+++ b/about.html
@@ -194,54 +194,60 @@
       <div class="footer-line"></div>
       <div class="social_medias">
         <div class="imgWrapper">
-          <i class="fa-brands fa-x-twitter"></i>
           <a href="https://twitter.com" class="socialmediaName" target="_blank"
-            >TWITTER</a
+            ><i class="fa-brands fa-x-twitter"></i>
+            <span>TWITTER</span></a
           >
         </div>
         <div class="imgWrapper">
-          <i class="fa-brands fa-facebook"></i>
           <a
             href="https://www.facebook.com"
             class="socialmediaName"
             target="_blank"
-            >FACEBOOK</a
+          >
+            <i class="fa-brands fa-facebook"></i>
+            <span>FACEBOOK</span></a
           >
         </div>
         <div class="imgWrapper">
-          <i class="fa-brands fa-instagram"></i>
+          
           <a
             href="https://www.instagram.com"
             class="socialmediaName"
             target="_blank"
-            >INSTAGRAM</a
+            >
+            <i class="fa-brands fa-instagram"></i>
+            <span>INSTAGRAM</span></a
           >
         </div>
         <div class="imgWrapper">
-          <i class="fa-brands fa-youtube"></i>
           <a
             href="https://www.youtube.com"
             class="socialmediaName"
             target="_blank"
-            >YOUTUBE</a
+            >
+            <i class="fa-brands fa-youtube"></i>
+            <span>YOUTUBE</span></a
           >
         </div>
         <div class="imgWrapper">
-          <i class="fa-brands fa-linkedin"></i>
           <a
             href="https://www.linkedin.com"
             class="socialmediaName"
             target="_blank"
-            >LINKEDIN</a
+            >
+            <i class="fa-brands fa-linkedin"></i>
+            <span>LINKEDIN</span></a
           >
         </div>
         <div class="imgWrapper">
-          <i class="fa-brands fa-github"></i>
           <a
             href="https://github.com/Virtual4087/Tree2Hope"
             class="socialmediaName"
             target="_blank"
-            >GITHUB</a
+            >
+            <i class="fa-brands fa-github"></i>
+            <span>GITHUB</span></a
           >
         </div>
       </div>

--- a/assets/css/responsiveness.css
+++ b/assets/css/responsiveness.css
@@ -92,6 +92,9 @@
   .socialmediaName {
     font-size: 0.8rem;
   }
+  .imgWrapper a span{
+    display: none;
+  }
   .banner::before {
     content: "";
     position: absolute;
@@ -179,14 +182,8 @@
     gap: 20px;
   }
 
-  .imgWrapper {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-  }
-  .imgWrapper i {
-    margin-right: 0px;
+  .imgWrapper a span{
+    display: none;
   }
   .banner::before {
     content: "";
@@ -298,14 +295,8 @@
     gap: 15px;
   }
 
-  .imgWrapper {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-  }
-  .imgWrapper i {
-    margin-right: 0px;
+  .imgWrapper a span{
+    display: none;
   }
   .banner::before {
     content: "";

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -654,7 +654,6 @@ nav .nav_buttons {
   justify-content: space-between;
   display: flex;
   flex-direction: column;
-  height: 250px;
   width: 100%;
   /* background-color: red; */
 }
@@ -663,7 +662,7 @@ nav .nav_buttons {
   flex: 1.5;
   display: flex;
   justify-content: space-evenly;
-  margin: 0 10%;
+  margin: 1.5rem 10%;
   height: auto;
 }
 
@@ -780,17 +779,15 @@ nav .nav_buttons {
   right: 35%;
 }
 
-.imgWrapper {
+.imgWrapper a {
   display: flex;
   align-items: center;
   height: 32px;
-  /* cursor: pointer; */
   transition: transform 0.75s ease-in-out;
 }
 
 .imgWrapper i {
   font-size: 20px;
-  color: rgb(160, 160, 160);
   margin-right: 10px;
 }
 

--- a/index.html
+++ b/index.html
@@ -278,54 +278,60 @@
       <div class="footer-line"></div>
       <div class="social_medias">
         <div class="imgWrapper">
-          <i class="fa-brands fa-x-twitter"></i>
           <a href="https://twitter.com" class="socialmediaName" target="_blank"
-            >TWITTER</a
+            ><i class="fa-brands fa-x-twitter"></i>
+            <span>TWITTER</span></a
           >
         </div>
         <div class="imgWrapper">
-          <i class="fa-brands fa-facebook"></i>
           <a
             href="https://www.facebook.com"
             class="socialmediaName"
             target="_blank"
-            >FACEBOOK</a
+          >
+            <i class="fa-brands fa-facebook"></i>
+            <span>FACEBOOK</span></a
           >
         </div>
         <div class="imgWrapper">
-          <i class="fa-brands fa-instagram"></i>
+          
           <a
             href="https://www.instagram.com"
             class="socialmediaName"
             target="_blank"
-            >INSTAGRAM</a
+            >
+            <i class="fa-brands fa-instagram"></i>
+            <span>INSTAGRAM</span></a
           >
         </div>
         <div class="imgWrapper">
-          <i class="fa-brands fa-youtube"></i>
           <a
             href="https://www.youtube.com"
             class="socialmediaName"
             target="_blank"
-            >YOUTUBE</a
+            >
+            <i class="fa-brands fa-youtube"></i>
+            <span>YOUTUBE</span></a
           >
         </div>
         <div class="imgWrapper">
-          <i class="fa-brands fa-linkedin"></i>
           <a
             href="https://www.linkedin.com"
             class="socialmediaName"
             target="_blank"
-            >LINKEDIN</a
+            >
+            <i class="fa-brands fa-linkedin"></i>
+            <span>LINKEDIN</span></a
           >
         </div>
         <div class="imgWrapper">
-          <i class="fa-brands fa-github"></i>
           <a
             href="https://github.com/Virtual4087/Tree2Hope"
             class="socialmediaName"
             target="_blank"
-            >GITHUB</a
+            >
+            <i class="fa-brands fa-github"></i>
+            <span>GITHUB</span></a
           >
         </div>
       </div>


### PR DESCRIPTION
Before:
<img width="428" alt="Screenshot 2024-10-12 at 1 18 01 PM" src="https://github.com/user-attachments/assets/a817ec15-adea-4a34-b83d-adb8a9abf68d">

After: 
<img width="397" alt="Screenshot 2024-10-13 at 3 19 37 PM" src="https://github.com/user-attachments/assets/fbd81fd8-1f2b-40e2-87d2-7bf78ee62662">
