### PR TITLE
Changed the animation in get_involved section mb-5 class

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,12 +255,12 @@
             </button>
         </div>
 
-        <!--Added margin to bottom-->
         <div class="get_involved section mb-5">
-            <div class="Option" id="_1"   data-aos="fade-right" data-aos-duration="1000" data-aos-delay="100">INDIVIDUALS</div>
-            <div class="Option" id="_2"   data-aos="fade-left" data-aos-duration="1000" data-aos-delay="100">BUSINESSES</div>
-            <div class="Option" id="_3"   data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">SCHOOLS</div>
+            <div class="Option" id="_1" data-aos="zoom-in" data-aos-duration="1000" data-aos-delay="100">INDIVIDUALS</div>
+            <div class="Option" id="_2" data-aos="zoom-in" data-aos-duration="1000" data-aos-delay="100">BUSINESSES</div>
+            <div class="Option" id="_3" data-aos="zoom-in" data-aos-duration="1000" data-aos-delay="100">SCHOOLS</div> 
         </div>
+        
         <div id="events" class="events section"  data-aos="fade-up" data-aos-duration="1000" data-aos-delay="100">
             <div class="plant_with_us">
                 PLANT WITH US<span class="join_us"


### PR DESCRIPTION
I have updated the animation effects in the "get_involved section mb-5" section of the website. The previous animations using data-aos="fade-right", data-aos="fade-left", and data-aos="fade-up" have been replaced with a new zoom-in effect to enhance user engagement.

